### PR TITLE
Adding workflow for CI/CD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
           release_name: dbt-presto v${{env.version_number}}
           prerelease: ${{ steps.release_type.outputs.isPrerelease }}
           body: |
-            This is a patch release tracking [dbt-core v${{env.version_number}}](https://github.com/fishtown-analytics/dbt/releases/tag/v${{env.version_number}}).
+            Tracking [dbt-core v${{env.version_number}}](https://github.com/dbt-labs/dbt/releases/tag/v${{env.version_number}}).
 
             ```sh
             $ pip install dbt-presto==${{env.version_number}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,112 @@
+# Builds the presto plugin and releases it to GitHub and Pypi
+name: Build and Release
+
+on:
+  workflow_dispatch:
+  
+# Release version number that must be updated for each release
+env:
+  version_number: '0.19.2'
+
+jobs:          
+  Test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v2.2.2
+        with: 
+          python-version: '3.8'
+          
+      - uses: actions/checkout@v2
+
+      - name: Test release        
+        run: |
+          python3 -m venv env
+          source env/bin/activate
+          pip install -r dev_requirements.txt
+          pip install twine wheel setuptools
+          python setup.py sdist bdist_wheel
+          pip install dist/dbt-presto-*.tar.gz
+          pip install dist/dbt_presto-*-py3-none-any.whl
+          twine check dist/dbt_presto-*-py3-none-any.whl dist/dbt-presto-*.tar.gz
+
+  GitHubRelease:
+    name: GitHub release
+    runs-on: ubuntu-latest
+    needs: Test
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v2.2.2
+        with: 
+          python-version: '3.8'
+          
+      - uses: actions/checkout@v2
+
+      - name: Bumping version
+        run: |
+          python3 -m venv env
+          source env/bin/activate
+          pip install -r dev_requirements.txt
+          bumpversion --config-file .bumpversion-dbt.cfg patch --new-version ${{env.version_number}}
+          bumpversion --config-file .bumpversion.cfg patch --new-version ${{env.version_number}} --allow-dirty
+          git status
+
+      - name: Commit version bump and tag
+        uses: EndBug/add-and-commit@v7
+        with:
+          author_name: 'Leah Antkiewicz'
+          author_email: 'leah.antkiewicz@dbtlabs.com'
+          message: 'Bumping version to ${{env.version_number}}'
+          tag: v${{env.version_number}}
+          
+      # Need to set an output variable because env variables can't be taken as input
+      # This is needed for the next step with releasing to GitHub
+      - name: Find release type
+        id: release_type
+        env:
+          IS_PRERELEASE: ${{ contains(env.version_number, 'rc') ||  contains(env.version_number, 'b') }}
+        run: |
+          echo ::set-output name=isPrerelease::$IS_PRERELEASE
+          
+      - name: Create GitHub release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: v${{env.version_number}}
+          release_name: dbt-presto v${{env.version_number}}
+          prerelease: ${{ steps.release_type.outputs.isPrerelease }}
+          body: |
+            This is a patch release tracking [dbt-core v${{env.version_number}}](https://github.com/fishtown-analytics/dbt/releases/tag/v${{env.version_number}}).
+
+            ```sh
+            $ pip install dbt-presto==${{env.version_number}}
+            ```
+          
+  PypiRelease:
+    name: Pypi release
+    runs-on: ubuntu-latest
+    needs: GitHubRelease
+    environment: PypiProd
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v2.2.2
+        with: 
+          python-version: '3.8'
+          
+      - uses: actions/checkout@v2
+        with:
+          ref: v${{env.version_number}}
+      
+      - name: Release to pypi
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python3 -m venv env
+          source env/bin/activate
+          pip install -r dev_requirements.txt
+          pip install twine wheel setuptools
+          python setup.py sdist bdist_wheel
+          twine upload --non-interactive dist/dbt_presto-${{env.version_number}}-py3-none-any.whl dist/dbt-presto-${{env.version_number}}.tar.gz
+          


### PR DESCRIPTION
This will automate the release of the presto plugin. I tested on a fork of mine and verified it running there. I still don't know Python well to know if there are extra steps in there I added that might not be necessary. 

We will still need to update this workflow file with the new version we are bumping to each time since Actions doesn't take any input.