### PR TITLE
Fix unit tests in test_adapter to Remove Deprecation Warnings

### DIFF
--- a/test/unit/test_adapter.py
+++ b/test/unit/test_adapter.py
@@ -51,8 +51,8 @@ class TestPrestoAdapter(unittest.TestCase):
 
         connection.handle
 
-        self.assertEquals(connection.state, 'open')
-        self.assertNotEquals(connection.handle, None)
+        self.assertEqual(connection.state, 'open')
+        self.assertNotEqual(connection.handle, None)
 
     def test_cancel_open_connections_empty(self):
         self.assertEqual(len(list(self.adapter.cancel_open_connections())), 0)


### PR DESCRIPTION
I noticed when working in the repository that there were some deprecation warnings. This PR uses follow the suggestion in the deprecation message and uses the new assertion functions.

Before:
```
$ pytest test
============================================================================================================================= test session starts ==============================================================================================================================
platform darwin -- Python 3.8.5, pytest-5.4.2, py-1.10.0, pluggy-0.13.1
collected 3 items

test/unit/test_adapter.py ...                                                                                                                                                                                                                                            [100%]

=============================================================================================================================== warnings summary ===============================================================================================================================
test/unit/test_adapter.py::TestPrestoAdapter::test_acquire_connection
DeprecationWarning: Please use assertEqual instead.

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================================================================================= 3 passed, 1 warning in 1.05s =========================================================================================================================
```

After:
```
$ pytest test
============================================================================================================================= test session starts ==============================================================================================================================
platform darwin -- Python 3.8.5, pytest-5.4.2, py-1.10.0, pluggy-0.13.1
collected 3 items

test/unit/test_adapter.py ...                                                                                                                                                                                                                                            [100%]

============================================================================================================================== 3 passed in 1.11s ===============================================================================================================================
```