### PR TITLE
Support to add with properties when creating Trino/Presto tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,23 @@ hive.allow-drop-table=true
 hive.allow-rename-table=true
 ```
 
+#### Use table properties to configure connector specifics
+
+Trino/Presto connectors use table properties to configure connector specifics.
+
+Check the Presto/Trino connector documentation for more information.
+
+```
+{{
+  config(
+    materialized='table',
+    properties={
+      "format": "'PARQUET'",
+      "partitioning": "ARRAY['bucket(id, 2)']",
+    }
+  )
+}}
+```
 
 ### Reporting bugs and contributing code
 

--- a/dbt/adapters/presto/impl.py
+++ b/dbt/adapters/presto/impl.py
@@ -1,12 +1,21 @@
+from dataclasses import dataclass
+from typing import Dict, Optional
 from dbt.adapters.sql import SQLAdapter
 from dbt.adapters.presto import PrestoConnectionManager, PrestoColumn
+from dbt.adapters.base.impl import AdapterConfig
 
 import agate
+
+
+@dataclass
+class PrestoConfig(AdapterConfig):
+    properties: Optional[Dict[str, str]] = None
 
 
 class PrestoAdapter(SQLAdapter):
     Column = PrestoColumn
     ConnectionManager = PrestoConnectionManager
+    AdapterSpecificConfigs = PrestoConfig
 
     @classmethod
     def date_function(cls):

--- a/dbt/include/presto/macros/adapters.sql
+++ b/dbt/include/presto/macros/adapters.sql
@@ -57,9 +57,45 @@
 {% endmacro %}
 
 
+{% macro presto__create_csv_table(model, agate_table) %}
+  {%- set column_override = model['config'].get('column_types', {}) -%}
+  {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}
+  {%- set _properties = config.get('properties') -%}
+
+  {% set sql %}
+    create table {{ this.render() }} (
+        {%- for col_name in agate_table.column_names -%}
+            {%- set inferred_type = adapter.convert_type(agate_table, loop.index0) -%}
+            {%- set type = column_override.get(col_name, inferred_type) -%}
+            {%- set column_name = (col_name | string) -%}
+            {{ adapter.quote_seed_column(column_name, quote_seed_column) }} {{ type }} {%- if not loop.last -%}, {%- endif -%}
+        {%- endfor -%}
+    ) {{ properties(_properties) }}
+  {% endset %}
+
+  {% call statement('_') -%}
+    {{ sql }}
+  {%- endcall %}
+
+  {{ return(sql) }}
+{% endmacro %}
+
+{% macro properties(properties) %}
+  {%- if properties is not none -%}
+      WITH (
+          {%- for key, value in properties.items() -%}
+            {{ key }} = {{ value }}
+            {%- if not loop.last -%}{{ ',\n  ' }}{%- endif -%}
+          {%- endfor -%}
+      )
+  {%- endif -%}
+{%- endmacro -%}
+
+
 {% macro presto__create_table_as(temporary, relation, sql) -%}
-  create table
-    {{ relation }}
+  {%- set _properties = config.get('properties') -%}
+  create table {{ relation }}
+    {{ properties(_properties) }}
   as (
     {{ sql }}
   );

--- a/test/unit/test_adapter.py
+++ b/test/unit/test_adapter.py
@@ -51,8 +51,8 @@ class TestPrestoAdapter(unittest.TestCase):
 
         connection.handle
 
-        self.assertEquals(connection.state, 'open')
-        self.assertNotEquals(connection.handle, None)
+        self.assertEqual(connection.state, 'open')
+        self.assertNotEqual(connection.handle, None)
 
     def test_cancel_open_connections_empty(self):
         self.assertEqual(len(list(self.adapter.cancel_open_connections())), 0)


### PR DESCRIPTION
Fixes #53 

By adding with_props in the model, we can enable users to add properties when creating tables. As presto/Trino supports a lot of different adapters, for now a Dict[String, String] type enables flexibility.

````
{{
  config(
    materialized='table',
    with_props={
      "format": "'PARQUET'",
      "partitioning": "ARRAY['bucket(id, 2)']",
    }
  )
}}
select 
  * 
from {{ source('inventory', 'products') }}
WHERE weight < 5
```
Following query is executed on Trino

```
create table "iceberg"."datalake"."low_weight_products__dbt_tmp"
    WITH (format = 'PARQUET',partitioning = ARRAY['bucket(id, 2)'])
  as (
    
select 
  * 
from "postgres"."inventory"."products"
WHERE weight < 5
  )
```