### PR TITLE
configurable http_headers and http_scheme in presto profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ A dbt profile can be configured to run against Presto using the following config
 | method  | The Presto authentication method to use | Optional (default is `none`)  | `none` or `kerberos` |
 | user  | Username for authentication | Required  | `drew` |
 | password  | Password for authentication | Optional (required if `method` is `ldap` or `kerberos`)  | `none` or `abc123` |
+| http_headers | HTTP Headers to send alongside requests to Presto, specified as a yaml dictionary of (header, value) pairs. | Optional |  `X-Presto-Routing-Group: my-cluster`|
+| http_scheme | The HTTP scheme to use for requests to Presto | Optional (default is `http`, or `https` for `method: kerberos` and `method: ldap`) | `https` or `http`
 | database  | Specify the database to build models into | Required  | `analytics` |
 | schema  | Specify the schema to build models into. Note: it is not recommended to use upper or mixed case schema names | Required | `dbt_drew` |
 | host    | The hostname to connect to | Required | `127.0.0.1`  |

--- a/dbt/adapters/presto/connections.py
+++ b/dbt/adapters/presto/connections.py
@@ -157,12 +157,16 @@ class PrestoConnectionManager(SQLConnectionManager):
                 credentials.password,
             )
             if credentials.http_scheme and credentials.http_scheme != "https":
-                raise dbt.exceptions.RuntimeException("http_scheme must be set to 'https' for 'ldap' method.")
+                raise dbt.exceptions.RuntimeException(
+                    "http_scheme must be set to 'https' for 'ldap' method."
+                )
             http_scheme = "https"
         elif credentials.method == 'kerberos':
             auth = prestodb.auth.KerberosAuthentication()
             if credentials.http_scheme and credentials.http_scheme != "https":
-                raise dbt.exceptions.RuntimeException("http_scheme must be set to 'https' for 'kerberos' method.")
+                raise dbt.exceptions.RuntimeException(
+                    "http_scheme must be set to 'https' for 'kerberos' method."
+                )
             http_scheme = "https"
         else:
             auth = prestodb.constants.DEFAULT_AUTH

--- a/dbt/adapters/presto/connections.py
+++ b/dbt/adapters/presto/connections.py
@@ -6,7 +6,7 @@ from dbt.adapters.sql import SQLConnectionManager
 from dbt.logger import GLOBAL_LOGGER as logger
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Dict
 from dbt.helper_types import Port
 
 from datetime import datetime
@@ -24,6 +24,8 @@ class PrestoCredentials(Credentials):
     user: str
     password: Optional[str] = None
     method: Optional[str] = None
+    http_headers: Optional[Dict[str, str]] = None
+    http_scheme: Optional[str] = None
     _ALIASES = {
         'catalog': 'database'
     }
@@ -154,13 +156,17 @@ class PrestoConnectionManager(SQLConnectionManager):
                 credentials.user,
                 credentials.password,
             )
+            if credentials.http_scheme and credentials.http_scheme != "https":
+                raise dbt.exceptions.RuntimeException("http_scheme must be set to 'https' for 'ldap' method.")
             http_scheme = "https"
         elif credentials.method == 'kerberos':
             auth = prestodb.auth.KerberosAuthentication()
+            if credentials.http_scheme and credentials.http_scheme != "https":
+                raise dbt.exceptions.RuntimeException("http_scheme must be set to 'https' for 'kerberos' method.")
             http_scheme = "https"
         else:
             auth = prestodb.constants.DEFAULT_AUTH
-            http_scheme = "http"
+            http_scheme = credentials.http_scheme or "http"
 
         # it's impossible for presto to fail here as 'connections' are actually
         # just cursor factories.
@@ -171,6 +177,7 @@ class PrestoConnectionManager(SQLConnectionManager):
             catalog=credentials.database,
             schema=credentials.schema,
             http_scheme=http_scheme,
+            http_headers=credentials.http_headers,
             auth=auth,
             isolation_level=IsolationLevel.AUTOCOMMIT
         )


### PR DESCRIPTION
Issue: https://github.com/dbt-labs/dbt-presto/issues/68

## 🎩 Tophatting: 

### Profile with configured `http_headers` and `http_scheme`, no `method`: 
```
trino:
  target: dev
  outputs:
    dev:
      type: presto
      http_scheme: https
      http_headers:
        Authorization: "{{ env_var('TOKEN') }}"
        X-Presto-Routing-Group: seamster
      user: none
      host: <some-host>
      port: <some-port>
      database: seamster
      schema: seamster_dev
      threads: 8
```

```python
bin/dbt run --profile trino --model my_first_dbt_model
Running with dbt=0.20.0-rc2
Partial parsing enabled: 0 files deleted, 0 files added, 0 files changed.
Partial parsing enabled, no changes found, skipping parsing
Found 558 models, 153 tests, 0 snapshots, 1 analysis, 366 macros, 0 operations, 0 seed files, 337 sources, 0 exposures

14:24:46 | Concurrency: 8 threads (target='dev')
14:24:46 | 
14:24:46 | 1 of 1 START view model seamster_dev.my_first_dbt_model.............. [RUN]
14:24:48 | 1 of 1 OK created view model seamster_dev.my_first_dbt_model......... [OK in 1.74s]
14:24:49 | 
14:24:49 | Finished running 1 view model in 5.01s.

Completed successfully

Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

### Profile with `method: ldap` and `http_scheme` set to something other than `https`: 

✅ Same tophatting done for `method: kerberos`

```python
~/src/github.com/Shopify/seamster(master*) » bin/dbt run --profile trino --model my_first_dbt_model
Running with dbt=0.20.0-rc2
Unable to do partial parsing because profile has changed
Found 558 models, 153 tests, 0 snapshots, 1 analysis, 366 macros, 0 operations, 0 seed files, 337 sources, 0 exposures

Encountered an error:
Runtime Error
  Runtime Error
    Runtime Error
      http_scheme must be set to 'https' for 'ldap' method.
```
